### PR TITLE
[chore] add image variable for opensearch base template

### DIFF
--- a/opensearch.yaml
+++ b/opensearch.yaml
@@ -6,7 +6,7 @@ base:
   defines: runnable
   containers:
     node:
-      image: opensearchproject/opensearch:latest
+      image: <- `${image}`
       paths:
         - '<- `${monk-volume-path}/opensearch:/usr/share/opensearch/data`'
       ulimits:
@@ -30,7 +30,10 @@ base:
       host-port: 9600
       publish: false
   variables:
-    defines: variables
+    image:
+      description: Set the OpenSearch image.
+      type: string
+      value: "opensearchproject/opensearch:3"
     cluster-name:
       description: Set the cluster name for OpenSearch.
       type: string
@@ -46,11 +49,11 @@ base:
       type: bool
       value: true
       env: "DISABLE_SECURITY_PLUGIN"
-#    bootstrap:
-#      description: Set the bootstrap memory lock for OpenSearch.
-#      type: string
-#      value: "true"
-#      env: "bootstrap.memory_lock"
+    #    bootstrap:
+    #      description: Set the bootstrap memory lock for OpenSearch.
+    #      type: string
+    #      value: "true"
+    #      env: "bootstrap.memory_lock"
     opensearch:
       description: Set the OpenSearch memory lock for OpenSearch.
       type: string
@@ -190,5 +193,3 @@ single-node-stack:
   runnable-list:
     - opensearch/single-node
     - opensearch/opensearch-single-dashboards
-
-


### PR DESCRIPTION
This pull request updates the `opensearch.yaml` configuration to make the OpenSearch container image configurable via a variable, improving flexibility for deployments.

Configuration improvements:

* Changed the `node` container's `image` field to use a variable (`${image}`) instead of a hardcoded value, allowing for easier updates and customization.
* Added an `image` variable under the `variables` section with a default value of `opensearchproject/opensearch:3`, enabling users to specify which OpenSearch image version to use.